### PR TITLE
fixing non-english clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # MMR Tracker
 
+## [v1.1.1](https://github.com/rbgdevx/mmr-tracker/releases/tag/v1.1.1) (2025-03-10)
+
+- Changing rated arena win team names to fix non-english client name matching and adding fallback just incase
+- Hiding intro text when season data becomes present
+
 ## [v1.1.0](https://github.com/rbgdevx/mmr-tracker/releases/tag/v1.1.0) (2025-03-05)
 
 - Starting to track season for each game so the table view can be filtered by season and default to the current season
-- Resetting hide into text when new seasons begin
+- Resetting hide intro text when new seasons begin
 - Fixing bug when there is no shuffle data available
 - Adding data migration for everyone who installed the addon previous to this update to add season info
 - Update toc

--- a/MMRTracker.toc
+++ b/MMRTracker.toc
@@ -1,6 +1,6 @@
 ## Interface: 110100
 ## Title: MMR Tracker
-## Version: 1.1.0
+## Version: 1.1.1
 ## Author: RBGDEV
 ## Notes: Tracks personal MMR and Rating for all pvp brackets
 ## OptionalDeps: AceConfig-3.0, AceGUI-3.0, AceGUI-3.0-SharedMediaWidgets, CallbackHandler-1.0, lib-st, LibDataBroker-1.1, LibDBIcon-1.0, LibSharedMedia-3.0, LibStub

--- a/helpers.lua
+++ b/helpers.lua
@@ -367,6 +367,7 @@ NS.DisplayBracketData = function()
         or playerData[bracketKey]
 
       if gameInfo[#gameInfo].season ~= nil and gameInfo[#gameInfo].season == NS.season then
+        NS.db.global.hideIntro = true
         hasAnySeasonData = true
 
         -- Format strings for display
@@ -487,10 +488,11 @@ NS.UpdateTable = function()
     local shuffleBracket = bracket == 6
     local bgString = gameInfo.faction == 0 and ("|cffFF0000" .. FACTION_HORDE .. "|r")
       or ("|cff00AAFF" .. FACTION_ALLIANCE .. "|r")
-    local GREEN_TEAM = VICTORY_TEXT_ARENA0:match("^(%w+)")
-    local GOLD_TEAM = VICTORY_TEXT_ARENA1:match("^(%w+)")
+    local GREEN_TEAM = VICTORY_TEXT_ARENA0:match("^(%S+)") or "Green"
+    local GOLD_TEAM = VICTORY_TEXT_ARENA1:match("^(%S+)") or "Gold"
     local arenaString = gameInfo.faction == 0 and ("|cFF90EE90" .. GREEN_TEAM .. "|r")
       or ("|cFFCC9900" .. GOLD_TEAM .. "|r")
+    -- VICTORY_TEXT_ARENA_WINS
     local shuffleString = "|cFFBBBBBB" .. "-" .. "|r"
     local bracketString = bgBracket and bgString or (shuffleBracket and shuffleString or arenaString)
     local classColors = (CUSTOM_CLASS_COLORS or RAID_CLASS_COLORS)[gameInfo.classToken]


### PR DESCRIPTION
- Changing rated arena win team names to fix non-english client name matching and adding fallback just incase
- Hiding intro text when season data becomes present